### PR TITLE
Fix JSON tooltip overflow on list annotations page

### DIFF
--- a/label_buddy/static/css/list_annotations.css
+++ b/label_buddy/static/css/list_annotations.css
@@ -25,3 +25,9 @@
     margin-right: 1%;
     margin-top: .5%;
 }
+/* Fix large JSON tooltip overflow */
+.tooltip-inner {
+    max-height: 300px;
+    overflow-y: auto;
+    text-align: left;
+}


### PR DESCRIPTION
Make large JSON tooltips scrollable to prevent viewport overflow.


### What this PR does
Fixes an issue where large JSON results shown in tooltips overflow the viewport on the List Annotations page.

### Changes made
- Made tooltip content scrollable by adding a max height and vertical scrolling
- Keeps existing tooltip behavior unchanged elsewhere

### Why this change
When hovering over large JSON results, the tooltip could extend beyond the bottom of the screen, affecting usability. Making the tooltip scrollable resolves this.

### How it was tested
- Ran the application locally
- Created an annotation with a large JSON result
- Verified the tooltip stays within the viewport and is scrollable

Fixes #36
